### PR TITLE
Configurable publishing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/lib/resource_subscriber.rb
+++ b/lib/resource_subscriber.rb
@@ -7,6 +7,7 @@ module ResourceSubscriber
 
   autoload :AutoInject
   autoload :Changes
+  autoload :Configuration
   autoload :Message
   autoload :Middlewares
   autoload :Railtie
@@ -17,6 +18,14 @@ module ResourceSubscriber
 
   def self.load_railtie
     ::ResourceSubscriber::Railtie
+  end
+
+  def self.configuration
+    @configuration ||= ::ResourceSubscriber::Configuration.with_defaults
+  end
+
+  def self.configure
+    yield(self.configuration) if block_given?
   end
 
   load_railtie if defined?(Rails)

--- a/lib/resource_subscriber.rb
+++ b/lib/resource_subscriber.rb
@@ -14,7 +14,6 @@ module ResourceSubscriber
   autoload :Resourceful
   autoload :Publishable
   autoload :Publisher
-  autoload :PublisherConfig
 
   def self.load_railtie
     ::ResourceSubscriber::Railtie

--- a/lib/resource_subscriber/configuration.rb
+++ b/lib/resource_subscriber/configuration.rb
@@ -1,12 +1,10 @@
-require "active_support/ordered_options"
-
 module ResourceSubscriber
-  class Configuration < ::ActiveSupport::InheritableOptions
+  class Configuration < ::ActiveSupport::OrderedOptions
     def self.with_defaults
-      new(
+      new({
         :exchange => 'events',
-        :publishing_options => { :content_type => 'application/json' }
-      )
+        :publishing_options => { :content_type => 'application/json' }.freeze
+      }.freeze)
     end
   end
 end

--- a/lib/resource_subscriber/configuration.rb
+++ b/lib/resource_subscriber/configuration.rb
@@ -1,0 +1,12 @@
+require "active_support/ordered_options"
+
+module ResourceSubscriber
+  class Configuration < ::ActiveSupport::InheritableOptions
+    def self.with_defaults
+      new(
+        :exchange => 'events',
+        :publishing_options => { :content_type => 'application/json' }
+      )
+    end
+  end
+end

--- a/lib/resource_subscriber/configuration.rb
+++ b/lib/resource_subscriber/configuration.rb
@@ -1,10 +1,10 @@
 module ResourceSubscriber
   class Configuration < ::ActiveSupport::OrderedOptions
     def self.with_defaults
-      new({
-        :exchange => 'events',
-        :publishing_options => { :content_type => 'application/json' }.freeze
-      }.freeze)
+      new.tap do |c|
+        c.exchange = 'events'
+        c.publishing_options = { :content_type => 'application/json' }.freeze
+      end
     end
   end
 end

--- a/lib/resource_subscriber/publishable.rb
+++ b/lib/resource_subscriber/publishable.rb
@@ -8,13 +8,14 @@ module ResourceSubscriber
       after_commit :publish_destroyed, :on => :destroy
 
       self.class_attribute :resource_publisher
-      self.resource_publisher = ::ResourceSubscriber::Publisher.new(model: self, config: ::ResourceSubscriber::PublisherConfig.new)
+
+      configuration = ::ResourceSubscriber.configuration.inheritable_copy
+      self.resource_publisher = ::ResourceSubscriber::Publisher.new(model: self, config: configuration)
     end
 
     module ClassMethods
-      def publish_to(routing_key, exchange:'events')
-        self.resource_publisher.config.exchange = exchange
-        self.resource_publisher.config.routing_key = routing_key
+      def publish_to(routing_key, &block)
+        self.resource_publisher.publish_as(routing_key, &block)
       end
     end
 

--- a/lib/resource_subscriber/publishable.rb
+++ b/lib/resource_subscriber/publishable.rb
@@ -9,7 +9,7 @@ module ResourceSubscriber
 
       self.class_attribute :resource_publisher
 
-      configuration = ::ResourceSubscriber.configuration.inheritable_copy
+      configuration = ::ResourceSubscriber.configuration.deep_dup
       self.resource_publisher = ::ResourceSubscriber::Publisher.new(model: self, config: configuration)
     end
 

--- a/lib/resource_subscriber/publisher.rb
+++ b/lib/resource_subscriber/publisher.rb
@@ -6,12 +6,12 @@ module ResourceSubscriber
 
     def publish_resource_message(action, resource)
       message = ::ResourceSubscriber::Message.new(resource)
-      ::ActionSubscriber::Publisher.publish_async("#{self.config.routing_key}.#{action}", message.to_json, self.config.exchange, :content_type => 'application/json')
+      ::ActionSubscriber::Publisher.publish_async("#{self.config.routing_key}.#{action}", message.to_json, self.config.exchange, self.config.publishing_options)
     end
 
-    def publish_as(routing_key, exchange:'events')
-      self.config[:exchange] = exchange
-      self.config[:routing_key] = routing_key
+    def publish_as(routing_key)
+      yield(self.config) if block_given?
+      self.config.routing_key = routing_key
     end
   end
 end

--- a/lib/resource_subscriber/publisher_config.rb
+++ b/lib/resource_subscriber/publisher_config.rb
@@ -1,9 +1,0 @@
-module ResourceSubscriber
-  class PublisherConfig < ::ActiveSupport::InheritableOptions
-    def initialize(*args)
-      super(*args)
-
-      self[:exchange] = "events"
-    end
-  end
-end

--- a/spec/lib/resource_subscriber/publishable_spec.rb
+++ b/spec/lib/resource_subscriber/publishable_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ResourceSubscriber::Publishable do
+  let(:publisher_config) { klass.resource_publisher.config }
+
+  subject(:klass) {
+    Class.new {
+      def self.after_commit(*args); end
+      include ResourceSubscriber::Publishable
+    }
+  }
+
+  describe '::publish_to' do
+    let(:routing_key) { 'route.this.way' }
+
+    it { expect(publisher_config).not_to be(ResourceSubscriber.configuration) }
+
+    context "override global config" do
+      let(:exchange_override) { 'override' }
+      let(:publishing_options_override) { {:persistent => true } }
+
+      before do
+        klass.publish_to(routing_key) do |config|
+          config.routing_key = 'should.be.ignored'
+          config.exchange = exchange_override
+          config.publishing_options = publishing_options_override
+        end
+      end
+
+      it { expect(publisher_config.routing_key).to eq(routing_key) }
+      it { expect(publisher_config.exchange).to eq(exchange_override) }
+      it { expect(publisher_config.publishing_options).to eq(publishing_options_override) }
+    end
+  end
+end

--- a/spec/resource_subscriber_spec.rb
+++ b/spec/resource_subscriber_spec.rb
@@ -4,4 +4,29 @@ describe ResourceSubscriber do
   it 'has a version number' do
     expect(ResourceSubscriber::VERSION).not_to be nil
   end
+
+  describe '::configuration' do
+    subject { ResourceSubscriber.configuration }
+
+    it { expect(subject).to be(ResourceSubscriber.configuration) }
+    it { expect(subject.exchange).to be_a(String) }
+    it { expect(subject.publishing_options).to be_a(Hash) }
+  end
+
+  describe '::configure' do
+    let(:exchange) { "NYSE" }
+    let(:publishing_options) { { :mandatory => true, :persistent => true } }
+
+    subject { ResourceSubscriber.configuration }
+
+    before do
+      ResourceSubscriber.configure do |config|
+        config.exchange = exchange
+        config.publishing_options = publishing_options
+      end
+    end
+
+    it { expect(subject.exchange).to be(exchange) }
+    it { expect(subject.publishing_options).to be(publishing_options) }
+  end
 end


### PR DESCRIPTION
Created a configuration object with the additional option for publishing options (a.k.a. message metadata in Bunny). The publishing options as well as other options (such as the exchange) can be configured globally or for a specific publisher.
