### PR TITLE
use find_by when finding resource since ack never gets called if it b…

### DIFF
--- a/lib/resource_subscriber/middlewares/resourceful.rb
+++ b/lib/resource_subscriber/middlewares/resourceful.rb
@@ -8,7 +8,7 @@ module ResourceSubscriber
       def call(env)
         attributes = env["payload"]["resource"]
         model = env["payload"]["resource_type"].constantize
-        env["resource"] = model.find(attributes["id"])
+        env["resource"] = model.find_by(:id => attributes["id"])
         @app.call(env)
       end
     end


### PR DESCRIPTION
use find_by when finding resource since ack never gets called if it breaks at this level.

If the subscriber is able to attempt to process the message, it will reach the error handler middleware, which will fail, but still acknowledge that the message was processed.

Not sure it's the best way to go about it, but it works for now. - The tradeoff is, ack will always be called now, but since resource could be nil, we may see a blowup which is less obvious when the subscriber actually does its thang

