### PR TITLE
Override middleware runner

### DIFF
--- a/lib/resource_subscriber.rb
+++ b/lib/resource_subscriber.rb
@@ -10,6 +10,7 @@ module ResourceSubscriber
   autoload :Configuration
   autoload :Message
   autoload :Middlewares
+  autoload :MiddlewareRunner
   autoload :Railtie
   autoload :Resourceful
   autoload :Publishable

--- a/lib/resource_subscriber/middleware_runner.rb
+++ b/lib/resource_subscriber/middleware_runner.rb
@@ -1,0 +1,14 @@
+require 'middleware/runner'
+
+module ResourceSubscriber
+  class MiddlewareRunner < ::Middleware::Runner
+    # Override the default middleware runner so we can ensure that the
+    # router is the last thing called in the stack.
+    #
+    def initialize(stack)
+      stack << ::ResourceSubscriber::Middlewares::Router
+
+      super(stack)
+    end
+  end
+end

--- a/lib/resource_subscriber/middlewares.rb
+++ b/lib/resource_subscriber/middlewares.rb
@@ -4,5 +4,6 @@ module ResourceSubscriber
 
     autoload :HasChanges
     autoload :Resourceful
+    autoload :Router
   end
 end

--- a/lib/resource_subscriber/middlewares/resourceful.rb
+++ b/lib/resource_subscriber/middlewares/resourceful.rb
@@ -12,6 +12,7 @@ module ResourceSubscriber
         env["resource"] = if env["action"] == :destroyed
           record = model.instantiate(attributes)
           record.instance_variable_set(:@destroyed, true)
+          record.freeze
           record
         else
           model.find_by(:id => attributes["id"])

--- a/lib/resource_subscriber/middlewares/resourceful.rb
+++ b/lib/resource_subscriber/middlewares/resourceful.rb
@@ -8,7 +8,15 @@ module ResourceSubscriber
       def call(env)
         attributes = env["payload"]["resource"]
         model = env["payload"]["resource_type"].constantize
-        env["resource"] = model.find_by(:id => attributes["id"])
+
+        env["resource"] = if env["action"] == :destroyed
+          record = model.instantiate(attributes)
+          record.instance_variable_set(:@destroyed, true)
+          record
+        else
+          model.find_by(:id => attributes["id"])
+        end
+
         @app.call(env)
       end
     end

--- a/lib/resource_subscriber/middlewares/router.rb
+++ b/lib/resource_subscriber/middlewares/router.rb
@@ -1,0 +1,23 @@
+module ResourceSubscriber
+  module Middlewares
+    class Router
+      include ::ActionSubscriber::Logging
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        logger.info "START #{env.message_id} #{env.subscriber}##{env.action}"
+
+        result = if env["resource"]
+          env.subscriber.run_action_with_filters(env, env.action)
+        else
+          env.acknowledge
+        end
+
+        logger.info "FINISHED #{env.message_id}"
+      end
+    end
+  end
+end

--- a/lib/resource_subscriber/middlewares/router.rb
+++ b/lib/resource_subscriber/middlewares/router.rb
@@ -10,7 +10,7 @@ module ResourceSubscriber
       def call(env)
         logger.info "START #{env.message_id} #{env.subscriber}##{env.action}"
 
-        result = if env["resource"]
+        if env["resource"]
           env.subscriber.run_action_with_filters(env, env.action)
         else
           env.acknowledge

--- a/lib/resource_subscriber/railtie.rb
+++ b/lib/resource_subscriber/railtie.rb
@@ -4,6 +4,7 @@ module ResourceSubscriber
       stack :resourceful do
         use ::ResourceSubscriber::Middlewares::HasChanges
         use ::ResourceSubscriber::Middlewares::Resourceful
+        self.instance_variable_set(:@runner_class, ::ResourceSubscriber::MiddlewareRunner)
 
         ::ActiveSupport.run_load_hooks(:resource_subscriber_resourceful_stack, self)
         self


### PR DESCRIPTION
1. fix acknowledgement the "right way", by not calling the subscriber action if the resource couldn't be loaded
2. adds support for destroyed records, by instantiating the destroyed record manually and freezing it